### PR TITLE
disk object storage vfs metrics and settings

### DIFF
--- a/docs/en/engines/table-engines/mergetree-family/mergetree.md
+++ b/docs/en/engines/table-engines/mergetree-family/mergetree.md
@@ -826,7 +826,7 @@ Tags:
 - `<disk_name_N>` — Disk name. Names must be different for all disks.
 - `path` — path under which a server will store data (`data` and `shadow` folders), should be terminated with ‘/’.
 - `keep_free_space_bytes` — the amount of free disk space to be reserved.
-- `allow_vfs` and `vfs_gc_sleep_ms` -- settings for [Disk VFS](#disk-vfs).
+- `allow_vfs` and number of settings with prefix `vfs` (e.g. `vfs_gc_sleep_ms`) -- settings for [Disk VFS](#disk-vfs).
 
 The order of the disk definition is not important.
 
@@ -956,9 +956,13 @@ When turned on, reuses the following settings:
 - `remote_fs_execute_merges_on_single_replica_time_threshold`
 - `zero_copy_merge_mutation_min_parts_size_sleep_before_lock`
 
-
-`vfs_gc_sleep_ms` disk setting handles garbage collector sleep timeout between iterations for VFS disks
-(default: 10'000).
+VFS specific settings
+`vfs_gc_sleep_ms` — sleep timeout between iterations for VFS disks
+(default: 1'000).
+`vfs_batch_min_size` — allowed to skip gc run if log batch size is smaller
+`vfs_batch_max_size` — max log batch size to process at once
+`vfs_batch_can_wait_milliseconds` — allowed to skip gc run if log batch is younger then specified
+`vfs_snapshot_lz4_compression_level` — VFS snapshot compression
 
 ### Dynamic Storage
 

--- a/src/Common/ProfileEvents.cpp
+++ b/src/Common/ProfileEvents.cpp
@@ -594,6 +594,13 @@ The server successfully detected this situation and will download merged part fr
     \
     M(AsyncLoaderWaitMicroseconds, "Total time a query was waiting for async loader jobs.") \
     \
+    M(VFSGcRunsCompleted, "Number of successful VFS Garbage Collector runs.")\
+    M(VFSGcRunsException, "Number of VFS Garbage Collector runs raised an exception.")\
+    M(VFSGcRunsSkipped, "Number of VFS Garbage Collector runs skipped because of settings (e.g. small number of operations)")\
+    M(VFSGcTotalMicroseconds, "Total time took by VFS Garbage Collector.")\
+    M(VFSGcCummulativeSnapshotBytesRead, "Total size of snapshots read from Object Storage by VFS Garbage Collector.")\
+    M(VFSGcCummulativeLogItemsRead, "Total number of log items from keeper by VFS Garbage Collector.")\
+    \
     M(LogTest, "Number of log messages with level Test") \
     M(LogTrace, "Number of log messages with level Trace") \
     M(LogDebug, "Number of log messages with level Debug") \

--- a/src/Disks/ObjectStorages/DiskObjectStorageVFS.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageVFS.cpp
@@ -29,8 +29,9 @@ DiskObjectStorageVFS::DiskObjectStorageVFS(
         config,
         config_prefix)
     , enable_gc(enable_gc_)
-    , gc_sleep_ms(config.getUInt64(config_prefix + ".vfs_gc_sleep_ms", 10'000))
     , traits(VFSTraits{name_})
+    , settings(config, config_prefix)
+    // , gc_sleep_ms(config.getUInt64(config_prefix + ".vfs_gc_sleep_ms", 10'000))
 {
     if (send_metadata)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "VFS doesn't support send_metadata");

--- a/src/Disks/ObjectStorages/DiskObjectStorageVFS.cpp
+++ b/src/Disks/ObjectStorages/DiskObjectStorageVFS.cpp
@@ -31,7 +31,6 @@ DiskObjectStorageVFS::DiskObjectStorageVFS(
     , enable_gc(enable_gc_)
     , traits(VFSTraits{name_})
     , settings(config, config_prefix)
-    // , gc_sleep_ms(config.getUInt64(config_prefix + ".vfs_gc_sleep_ms", 10'000))
 {
     if (send_metadata)
         throw Exception(ErrorCodes::BAD_ARGUMENTS, "VFS doesn't support send_metadata");

--- a/src/Disks/ObjectStorages/DiskObjectStorageVFS.h
+++ b/src/Disks/ObjectStorages/DiskObjectStorageVFS.h
@@ -3,6 +3,7 @@
 #include "DiskObjectStorage.h"
 #include "ObjectStorageVFSGCThread.h"
 #include "VFSTraits.h"
+#include "VFSSettings.h"
 
 namespace DB
 {
@@ -48,8 +49,8 @@ private:
     std::optional<ObjectStorageVFSGCThread> garbage_collector;
 
     const bool enable_gc; // In certain conditions we don't want a GC e.g. when running from clickhouse-disks
-    const UInt64 gc_sleep_ms;
     const VFSTraits traits;
+    const VFSSettings settings;
 
     zkutil::ZooKeeperPtr zookeeper();
 

--- a/src/Disks/ObjectStorages/ObjectStorageVFSGCThread.h
+++ b/src/Disks/ObjectStorages/ObjectStorageVFSGCThread.h
@@ -27,7 +27,6 @@ private:
     String getNode(size_t id) const;
     StoredObject getSnapshotObject(size_t logpointer) const;
 
-    // returns true if we skip the run
-    bool skip(size_t batch_size, size_t log_pointer) const;
+    bool skipRun(size_t batch_size, size_t log_pointer) const;
 };
 }

--- a/src/Disks/ObjectStorages/ObjectStorageVFSGCThread.h
+++ b/src/Disks/ObjectStorages/ObjectStorageVFSGCThread.h
@@ -26,5 +26,8 @@ private:
     void removeBatch(size_t start_logpointer, size_t end_logpointer) const;
     String getNode(size_t id) const;
     StoredObject getSnapshotObject(size_t logpointer) const;
+
+    // returns true if we skip the run
+    bool pass(size_t batch_size, int64_t mtime) const;
 };
 }

--- a/src/Disks/ObjectStorages/ObjectStorageVFSGCThread.h
+++ b/src/Disks/ObjectStorages/ObjectStorageVFSGCThread.h
@@ -28,6 +28,6 @@ private:
     StoredObject getSnapshotObject(size_t logpointer) const;
 
     // returns true if we skip the run
-    bool pass(size_t batch_size, int64_t mtime) const;
+    bool skip(size_t batch_size, int64_t mtime) const;
 };
 }

--- a/src/Disks/ObjectStorages/ObjectStorageVFSGCThread.h
+++ b/src/Disks/ObjectStorages/ObjectStorageVFSGCThread.h
@@ -28,6 +28,6 @@ private:
     StoredObject getSnapshotObject(size_t logpointer) const;
 
     // returns true if we skip the run
-    bool skip(size_t batch_size, int64_t mtime) const;
+    bool skip(size_t batch_size, size_t log_pointer) const;
 };
 }

--- a/src/Disks/ObjectStorages/VFSSettings.h
+++ b/src/Disks/ObjectStorages/VFSSettings.h
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace DB
+{
+struct VFSSettings
+{
+    explicit VFSSettings(const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
+    : gc_sleep_ms(config.getUInt64(config_prefix + ".vfs_gc_sleep_ms", 10'000))
+    , batch_min_size(config.getUInt64(config_prefix + ".vfs_batch_min_size", 1))
+    , batch_max_size(config.getUInt64(config_prefix + ".vfs_batch_max_size", 100'000))
+    , batch_can_wait_milliseconds(config.getUInt64(config_prefix + ".vfs_batch_can_wait_milliseconds", 5'000))
+    , snapshot_lz4_compression_level(config.getInt(config_prefix + ".vfs_snapshot_lz4_compression_level", 8))
+    {
+    }
+    const UInt64 gc_sleep_ms;
+    const UInt64 batch_min_size;
+    const UInt64 batch_max_size;
+    const UInt64 batch_can_wait_milliseconds;
+    const Int16 snapshot_lz4_compression_level;
+};
+}

--- a/src/Disks/ObjectStorages/VFSSettings.h
+++ b/src/Disks/ObjectStorages/VFSSettings.h
@@ -5,10 +5,10 @@ namespace DB
 struct VFSSettings
 {
     explicit VFSSettings(const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
-    : gc_sleep_ms(config.getUInt64(config_prefix + ".vfs_gc_sleep_ms", 10'000))
+    : gc_sleep_ms(config.getUInt64(config_prefix + ".vfs_gc_sleep_ms", 5'000))
     , batch_min_size(config.getUInt64(config_prefix + ".vfs_batch_min_size", 1))
     , batch_max_size(config.getUInt64(config_prefix + ".vfs_batch_max_size", 100'000))
-    , batch_can_wait_milliseconds(config.getUInt64(config_prefix + ".vfs_batch_can_wait_milliseconds", 5'000))
+    , batch_can_wait_milliseconds(config.getUInt64(config_prefix + ".vfs_batch_can_wait_milliseconds", 10'000))
     , snapshot_lz4_compression_level(config.getInt(config_prefix + ".vfs_snapshot_lz4_compression_level", 8))
     {
     }

--- a/src/Disks/ObjectStorages/VFSSettings.h
+++ b/src/Disks/ObjectStorages/VFSSettings.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <Poco/Util/AbstractConfiguration.h>
+#include <base/defines.h>
 
 namespace DB
 {
@@ -18,4 +20,4 @@ struct VFSSettings
     const UInt64 batch_can_wait_milliseconds;
     const Int16 snapshot_lz4_compression_level;
 };
-}
+} // namespace DB

--- a/src/Disks/ObjectStorages/VFSSettings.h
+++ b/src/Disks/ObjectStorages/VFSSettings.h
@@ -5,10 +5,10 @@ namespace DB
 struct VFSSettings
 {
     explicit VFSSettings(const Poco::Util::AbstractConfiguration & config, const String & config_prefix)
-    : gc_sleep_ms(config.getUInt64(config_prefix + ".vfs_gc_sleep_ms", 5'000))
+    : gc_sleep_ms(config.getUInt64(config_prefix + ".vfs_gc_sleep_ms", 1'000))
     , batch_min_size(config.getUInt64(config_prefix + ".vfs_batch_min_size", 1))
     , batch_max_size(config.getUInt64(config_prefix + ".vfs_batch_max_size", 100'000))
-    , batch_can_wait_milliseconds(config.getUInt64(config_prefix + ".vfs_batch_can_wait_milliseconds", 10'000))
+    , batch_can_wait_milliseconds(config.getUInt64(config_prefix + ".vfs_batch_can_wait_milliseconds", 0))
     , snapshot_lz4_compression_level(config.getInt(config_prefix + ".vfs_snapshot_lz4_compression_level", 8))
     {
     }


### PR DESCRIPTION
## Documentation entry for user-facing changes

Settings:
vfs_gc_sleep_ms
vfs_batch_min_size
vfs_batch_max_size
vfs_batch_can_wait_milliseconds
vfs_snapshot_lz4_compression_level
Metrics:
VFSGcRunsCompleted
VFSGcRunsSkipped
VFSGcTotalMicroseconds
VFSGcCummulativeSnapshotBytesRead
VFSGcCummulativeLogItemsRead
